### PR TITLE
Update Chart.js dependency and remove the

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,6 @@
   "author": "Fangdun Cai <cfddream@gmail.com>",
   "license": "MIT",
   "dependencies": {
-    "chart.js": "2.2.0-rc.1"
+    "chart.js": "2.2.1"
   }
 }

--- a/src/Chartjs.vue
+++ b/src/Chartjs.vue
@@ -3,8 +3,7 @@
 </template>
 
 <script>
-// import Chart from 'chart.js' // With moment.js
-import Chart from 'chart.js/dist/Chart' // Without moment.js
+import Chart from 'chart.js' // With moment.js
 
 const types = ['line', 'bar', 'radar', 'polarArea', 'pie', 'doughnut']
 


### PR DESCRIPTION
"without Moment.js" import. Creates problems with browserify.

Chart.JS has moment.js as a dependency anyways. So this is probably a better of of doing this.
